### PR TITLE
Fix threshold relaxation after empty search result

### DIFF
--- a/lib/lafzi_dart.dart
+++ b/lib/lafzi_dart.dart
@@ -70,7 +70,8 @@ class LafziSearch {
     );
     double oldThreshold = threshold;
 
-    if (searched.isEmpty && (oldThreshold - threshold).abs() < 0.001) { // Check if threshold hasn't changed yet
+    if (searched.isEmpty && (oldThreshold - threshold).abs() < 0.001) {
+      // first relaxation attempt
       threshold = _optimizedThreshold(threshold);
       searched = await search(
         _dataIndex[mode]!,
@@ -78,8 +79,10 @@ class LafziSearch {
         threshold,
         mode,
       );
+      oldThreshold = threshold;
     }
-    if (searched.isEmpty && (oldThreshold - threshold).abs() < 0.001) { // Check again if threshold hasn't changed
+    if (searched.isEmpty && (oldThreshold - threshold).abs() < 0.001) {
+      // second relaxation attempt with updated baseline
       threshold = _optimizedThreshold(threshold);
       searched = await search(
         _dataIndex[mode]!,


### PR DESCRIPTION
## Summary
- Ensure `searchLafzi` lowers the search threshold twice by updating the baseline between attempts

## Testing
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a54b8aa54083289d9f426dc1325167