### PR TITLE
Add dynamic data download with caching

### DIFF
--- a/lib/src/data_parser.dart
+++ b/lib/src/data_parser.dart
@@ -23,27 +23,31 @@ Map<int, Map<int, String>> parseMuqathaat(String buffer) {
   return result;
 }
 
-/// Parses Quran text and translation buffers into a list of QuranVerse objects.
-/// @param bufferText The raw string content of quran_teks.txt
-/// @param bufferTrans The raw string content of quran_trans_indonesian.txt
-/// @returns A list of QuranVerse objects.
-List<QuranVerse> parseQuran(String bufferText, String bufferTrans) {
+/// Parses Quran text and optional translation buffers into a list of
+/// [QuranVerse] objects.
+///
+/// [bufferText] is the raw string content of `quran_teks.txt`.
+/// [bufferTrans] is the raw string content of `quran_trans_indonesian.txt` and
+/// may be omitted. When omitted, the `trans` field of each [QuranVerse] will be
+/// empty.
+List<QuranVerse> parseQuran(String bufferText, [String? bufferTrans]) {
   final lineText = bufferText.split('\n');
-  final lineTrans = bufferTrans.split('\n');
+  final lineTrans = bufferTrans?.split('\n') ?? [];
   final result = <QuranVerse>[];
 
   for (int i = 0; i < lineText.length; i++) {
-    if (i >= lineTrans.length) continue; // Ensure translation line exists
-
     final dataText = lineText[i].split('|');
-    final dataTrans = lineTrans[i].split('|');
+    final dataTrans = i < lineTrans.length ? lineTrans[i].split('|') : [];
 
-    if (dataText.length >= 4 && dataTrans.length >= 3) {
+    if (dataText.length >= 4) {
       final surah = int.tryParse(dataText[0]);
       final name = dataText[1];
       final ayat = int.tryParse(dataText[2]);
       final text = dataText[3];
-      final trans = dataTrans[2];
+      String trans = '';
+      if (dataTrans.length >= 3) {
+        trans = dataTrans[2];
+      }
 
       if (surah != null && ayat != null) {
         result.add(QuranVerse(
@@ -57,6 +61,18 @@ List<QuranVerse> parseQuran(String bufferText, String bufferTrans) {
     }
   }
   return result;
+}
+
+/// Updates the translation of an existing list of [QuranVerse] with the
+/// provided buffer from `quran_trans_indonesian.txt`.
+void updateQuranTranslation(List<QuranVerse> verses, String bufferTrans) {
+  final lineTrans = bufferTrans.split('\n');
+  for (int i = 0; i < lineTrans.length && i < verses.length; i++) {
+    final dataTrans = lineTrans[i].split('|');
+    if (dataTrans.length >= 3) {
+      verses[i] = verses[i].copyWith(trans: dataTrans[2]);
+    }
+  }
 }
 
 /// Converts a comma-delimited string to a list of integers.

--- a/lib/src/loaddata.dart
+++ b/lib/src/loaddata.dart
@@ -2,37 +2,88 @@ import 'dart:io';
 import 'dart:typed_data';
 import 'package:lafzi_dart/src/lzstring.dart';
 
-Future<Map<String, String>> loadData({LafziFileLoader? loader}) async {
+/// Placeholder URLs for remote data. Replace with real direct URLs.
+const String urlMuqathaat = 'https://example.com/muqathaat.lz';
+const String urlIndexV = 'https://example.com/index_v.lz';
+const String urlIndexNv = 'https://example.com/index_nv.lz';
+const String urlPosmapV = 'https://example.com/posmap_v.lz';
+const String urlPosmapNv = 'https://example.com/posmap_nv.lz';
+const String urlQuranText = 'https://example.com/quran_teks.lz';
+const String urlQuranTrans =
+    'https://example.com/quran_trans_indonesian.lz';
+
+class _DataFile {
+  final String name;
+  final String key;
+  final String url;
+  const _DataFile(this.name, this.key, this.url);
+}
+
+/// Downloads a file if it does not exist in cache and returns its bytes.
+Future<Uint8List> _loadOrDownload(
+  _DataFile file,
+  Directory cacheDir,
+  void Function(String message)? onProgress,
+) async {
+  final cached = File('${cacheDir.path}/${file.name}');
+  if (await cached.exists()) {
+    onProgress?.call('using cached ${file.name}');
+    return await cached.readAsBytes();
+  }
+
+  onProgress?.call('downloading ${file.name}');
+  final client = HttpClient();
+  final request = await client.getUrl(Uri.parse(file.url));
+  final response = await request.close();
+  final bytes = await response.fold<BytesBuilder>(
+      BytesBuilder(), (b, d) => b..add(d)).then((b) => b.takeBytes());
+  await cached.writeAsBytes(bytes, flush: true);
+  client.close();
+  return Uint8List.fromList(bytes);
+}
+
+/// Loads required data files, downloading them on the fly if necessary.
+///
+/// [loadQuranText] and [loadTranslation] control whether the Quran text and
+/// translation files are loaded in addition to the base index data.
+/// [cacheDir] specifies where downloaded files are stored. Defaults to a
+/// temporary directory.
+Future<Map<String, String>> loadData({
+  LafziFileLoader? loader,
+  bool loadQuranText = false,
+  bool loadTranslation = false,
+  void Function(String message)? onProgress,
+  Directory? cacheDir,
+}) async {
   final buffer = <String, String>{};
+  final dir = cacheDir ?? Directory('${Directory.systemTemp.path}/lafzi_cache');
+  if (!await dir.exists()) {
+    await dir.create(recursive: true);
+  }
 
-  final files = [
-    'data/muqathaat.lz',
-    'data/index_v.lz',
-    'data/index_nv.lz',
-    'data/posmap_v.lz',
-    'data/posmap_nv.lz',
-    'data/quran_teks.lz',
-    'data/quran_trans_indonesian.lz',
+  final files = <_DataFile>[
+    const _DataFile('muqathaat.lz', 'muqathaat', urlMuqathaat),
+    const _DataFile('index_v.lz', 'index_v', urlIndexV),
+    const _DataFile('index_nv.lz', 'index_nv', urlIndexNv),
+    const _DataFile('posmap_v.lz', 'posmap_v', urlPosmapV),
+    const _DataFile('posmap_nv.lz', 'posmap_nv', urlPosmapNv),
+    if (loadQuranText) const _DataFile('quran_teks.lz', 'quran_teks', urlQuranText),
+    if (loadTranslation)
+      const _DataFile('quran_trans_indonesian.lz',
+          'quran_trans_indonesian', urlQuranTrans),
   ];
-  final results = await Future.wait(
-    files.map((path) =>
-        loader == null ? File(path).readAsBytes() : loader.load(path)),
-  );
 
-  buffer['muqathaat'] =
-      (await LZString.decompressFromUint8Array(results[0])) ?? '';
-  buffer['index_v'] =
-      (await LZString.decompressFromUint8Array(results[1])) ?? '';
-  buffer['index_nv'] =
-      (await LZString.decompressFromUint8Array(results[2])) ?? '';
-  buffer['posmap_v'] =
-      (await LZString.decompressFromUint8Array(results[3])) ?? '';
-  buffer['posmap_nv'] =
-      (await LZString.decompressFromUint8Array(results[4])) ?? '';
-  buffer['quran_teks'] =
-      (await LZString.decompressFromUint8Array(results[5])) ?? '';
-  buffer['quran_trans_indonesian'] =
-      (await LZString.decompressFromUint8Array(results[6])) ?? '';
+  final results = await Future.wait(files.map((f) async {
+    if (loader != null) {
+      return await loader.load(f.name);
+    }
+    return await _loadOrDownload(f, dir, onProgress);
+  }));
+
+  for (int i = 0; i < files.length; i++) {
+    buffer[files[i].key] =
+        (await LZString.decompressFromUint8Array(results[i])) ?? '';
+  }
 
   return buffer;
 }

--- a/lib/src/quran_stub.dart
+++ b/lib/src/quran_stub.dart
@@ -1,0 +1,33 @@
+import 'models.dart';
+
+/// Verse counts for each surah in the Quran.
+/// Source: https://github.com/semarketir/quranjson
+const List<int> _surahVerseCounts = [
+  7, 286, 200, 176, 120, 165, 206, 75, 129, 109, 123, 111, 43, 52, 99, 128,
+  111, 110, 98, 135, 112, 78, 118, 64, 77, 227, 93, 88, 69, 60, 34, 30, 73,
+  54, 45, 83, 182, 88, 75, 85, 54, 53, 89, 59, 37, 35, 38, 29, 18, 45, 60,
+  49, 62, 55, 78, 96, 29, 22, 24, 13, 14, 11, 11, 18, 12, 12, 30, 52, 52,
+  44, 28, 28, 20, 56, 40, 31, 50, 40, 46, 42, 29, 19, 36, 25, 22, 17, 19,
+  26, 30, 20, 15, 21, 11, 8, 8, 19, 5, 8, 8, 11, 11, 8, 3, 9, 5, 4, 7, 3, 6,
+  3, 5, 4, 5, 6
+];
+
+/// Generates a stub of [QuranVerse] entries containing only surah and ayat
+/// numbers. Text and translation fields are left empty.
+List<QuranVerse> generateEmptyQuran() {
+  final result = <QuranVerse>[];
+  for (int s = 0; s < _surahVerseCounts.length; s++) {
+    final surah = s + 1;
+    final ayatCount = _surahVerseCounts[s];
+    for (int ayat = 1; ayat <= ayatCount; ayat++) {
+      result.add(QuranVerse(
+        surah: surah,
+        name: '',
+        ayat: ayat,
+        text: '',
+        trans: '',
+      ));
+    }
+  }
+  return result;
+}


### PR DESCRIPTION
## Summary
- Allow fetching compressed data files on demand with caching and placeholder URLs
- Support partial downloads for Quran text and translation and merge them into existing base data
- Expose search options to trigger downloads asynchronously with progress callbacks

## Testing
- `dart format lib` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*

------
https://chatgpt.com/codex/tasks/task_e_68a54dbdd3308328bd2eb14582867aeb