### PR TITLE
feat: load data from release URLs

### DIFF
--- a/lib/src/loaddata.dart
+++ b/lib/src/loaddata.dart
@@ -2,23 +2,56 @@ import 'dart:io';
 import 'dart:typed_data';
 import 'package:lafzi_dart/src/lzstring.dart';
 
-Future<Map<String, String>> loadData({LafziFileLoader? loader}) async {
-  final buffer = <String, String>{};
+Future<Uint8List> _download(String url) async {
+  final client = HttpClient()..followRedirects = true;
+  try {
+    final request = await client.getUrl(Uri.parse(url));
+    final response = await request.close();
+    if (response.statusCode != HttpStatus.ok) {
+      throw HttpException(
+          'Failed to GET $url (status ${response.statusCode})');
+    }
+    final builder = BytesBuilder();
+    await for (final data in response) {
+      builder.add(data);
+    }
+    return builder.toBytes();
+  } finally {
+    client.close();
+  }
+}
 
-  final files = [
-    'data/muqathaat.lz',
-    'data/index_v.lz',
-    'data/index_nv.lz',
-    'data/posmap_v.lz',
-    'data/posmap_nv.lz',
-    'data/quran_teks.lz',
-    'data/quran_trans_indonesian.lz',
+Future<Map<String, String>> loadData({LafziFileLoader? loader}) async {
+  const String urlMuqathaat =
+      'https://github.com/agusibrahim/lafzi_dart/releases/download/v0.1.0/muqathaat.lz';
+  const String urlIndexV =
+      'https://github.com/agusibrahim/lafzi_dart/releases/download/v0.1.0/index_v.lz';
+  const String urlIndexNv =
+      'https://github.com/agusibrahim/lafzi_dart/releases/download/v0.1.0/index_nv.lz';
+  const String urlPosmapV =
+      'https://github.com/agusibrahim/lafzi_dart/releases/download/v0.1.0/posmap_v.lz';
+  const String urlPosmapNv =
+      'https://github.com/agusibrahim/lafzi_dart/releases/download/v0.1.0/posmap_nv.lz';
+  const String urlQuranText =
+      'https://github.com/agusibrahim/lafzi_dart/releases/download/v0.1.0/quran_teks.lz';
+  const String urlQuranTrans =
+      'https://github.com/agusibrahim/lafzi_dart/releases/download/v0.1.0/quran_trans_indonesian.lz';
+
+  final urls = [
+    urlMuqathaat,
+    urlIndexV,
+    urlIndexNv,
+    urlPosmapV,
+    urlPosmapNv,
+    urlQuranText,
+    urlQuranTrans,
   ];
+
   final results = await Future.wait(
-    files.map((path) =>
-        loader == null ? File(path).readAsBytes() : loader.load(path)),
+    urls.map((url) => loader == null ? _download(url) : loader.load(url)),
   );
 
+  final buffer = <String, String>{};
   buffer['muqathaat'] =
       (await LZString.decompressFromUint8Array(results[0])) ?? '';
   buffer['index_v'] =


### PR DESCRIPTION
## Summary
- fetch Qur'an data directly from GitHub release URLs inside `loadData`
- ensure HTTP downloads follow redirects and remove unused download tool

## Testing
- `dart format lib/src/loaddata.dart` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5524090dc832891d162536ffb5891