### PR TITLE
docs: update README for new data loading and usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Lafzi Dart
 
-Lafzi Dart is a Dart library for searching Quranic verses using fuzzy matching and highlighting. It supports searching with various modes and provides verse details including translation and highlight positions.
+Lafzi Dart is a Dart library for searching Quranic verses using fuzzy matching and highlighting. It automatically downloads and caches the compressed data files needed for searching, and can optionally load the full verse text and Indonesian translation.
 
 This project is a Dart port of the original JavaScript project: [lafzi.js](https://github.com/lafzi/lafzi.js).
 
@@ -10,10 +10,14 @@ Uncompressed data can be found in the original project's repository: [lafzi.js/.
 
 ## Features
 
-- Fuzzy search for Quranic verses
-- Highlight matched text
-- Returns verse details: surah name, ayat number, text, translation, score, and highlight positions
-- No Flutter dependency; uses Dart IO for file access
+- Fuzzy search for Quranic verses.
+- Highlight matched text.
+- Returns verse details: surah name, ayat number, text, translation, score, and highlight positions.
+- Automatically downloads and caches required `.lz` data files.
+- Optional loading of Quran text and Indonesian translation.
+- Progress callback to report download and decompression steps.
+- No Flutter dependency; uses Dart IO for file access.
+- Pluggable `LafziFileLoader` for custom data sources (e.g. Flutter assets).
 
 ## Installation
 
@@ -30,46 +34,39 @@ Example usage in a Dart console app:
 
 ```dart
 import 'package:lafzi_dart/lafzi_dart.dart';
-import 'package:lafzi_dart/src/models.dart';
 
 void main() async {
   final lafziSearch = LafziSearch();
 
-  try {
-    final List<QuranVerse> result = await lafziSearch.searchLafzi(
-      mode: "v",
-      threshold: 0.95,
-      isHilight: true,
-      query: "sibgo",
-      multipleHighlightPos: false,
-    );
+  final result = await lafziSearch.searchLafzi(
+    query: 'sibgo',
+    mode: 'v',
+    threshold: 0.95,
+    loadQuranText: true,
+    loadTranslation: true,
+    onProcess: (msg) => print(msg),
+  );
 
-    if (result.isNotEmpty) {
-      print("Search Results for 'sibgo':");
-      for (final verse in result) {
-        print('Surah: ${verse.name}, Ayat: ${verse.ayat}');
-        print('Text: ${verse.text}');
-        print('Translation: ${verse.trans}');
-        if (verse.textHilight != null) {
-          print('Highlighted Text: ${verse.textHilight}');
-        }
-        print('Score: ${verse.score?.toStringAsFixed(4)}');
-        print('Highlight Positions: ${verse.highlightPos}');
-      }
-    } else {
-      print("No results found for 'sibgo'.");
+  for (final verse in result) {
+    print('Surah: ${verse.name}, Ayat: ${verse.ayat}');
+    print('Text: ${verse.text}');
+    print('Translation: ${verse.trans}');
+    if (verse.textHilight != null) {
+      print('Highlighted Text: ${verse.textHilight}');
     }
-  } catch (e) {
-    print("Error during search: $e");
+    print('Score: ${verse.score?.toStringAsFixed(4)}');
+    print('Highlight Positions: ${verse.highlightPos}');
   }
 }
 ```
 
+`loadQuranText` and `loadTranslation` control whether the verse text and Indonesian translation are downloaded and included in the results. If omitted, the fields will be empty. The optional `onProcess` callback provides messages about download and decompression progress. Data is cached in the system temporary directory by default; pass a custom `cacheDir` to `searchLafzi` to change the cache location.
+
 ## Custom File Loading
 
-The `LafziSearch` class requires an implementation of `LafziFileLoader` to load the necessary data files. This allows flexibility for different environments (e.g., pure Dart applications or Flutter applications).
+By default, `LafziSearch` downloads the required `.lz` data files from the GitHub release and caches them locally. In environments without network access or when bundling the data with your application, implement `LafziFileLoader` and pass it to `LafziSearch`.
 
-- **`DartFileLoader`**: For pure Dart applications (like console apps), you can use `DartFileLoader` which utilizes `dart:io` to read files from the file system.
+- **`DartFileLoader`**: Load files from the local file system in a pure Dart application.
 
   ```dart
   import 'dart:io';
@@ -78,43 +75,35 @@ The `LafziSearch` class requires an implementation of `LafziFileLoader` to load 
 
   class DartFileLoader implements LafziFileLoader {
     @override
-    Future<Uint8List> load(String path) {
-      final file = File(path);
-      return file.readAsBytes();
-    }
+    Future<Uint8List> load(String path) => File('data/$path').readAsBytes();
   }
 
-  // Initialize LafziSearch with DartFileLoader
   final lafziSearch = LafziSearch(lafziLoader: DartFileLoader());
   ```
 
-- **`FlutterFileLoader`**: For Flutter applications, you would typically load assets using `rootBundle`. An example `FlutterFileLoader` implementation would look like this (you'll need to uncomment and adapt this in your Flutter project):
+- **`FlutterFileLoader`**: Load files from Flutter assets.
 
 ```dart
-import 'package:flutter/services.dart' show rootBundle; Add this import
 import 'dart:typed_data';
+import 'package:flutter/services.dart' show rootBundle;
 import 'package:lafzi_dart/src/loaddata.dart';
 
 class FlutterFileLoader implements LafziFileLoader {
   @override
   Future<Uint8List> load(String path) async {
-    /* Make sure to add your data files to your pubspec.yaml under assets:
-    assets:
-      - assets/data/ 
-    */
-    final ByteData data = await rootBundle.load('assets/data/$path');
+    final data = await rootBundle.load('assets/data/$path');
     return data.buffer.asUint8List();
   }
 }
 
-Initialize LafziSearch with FlutterFileLoader
 final lafziSearch = LafziSearch(lafziLoader: FlutterFileLoader());
-  ```
-  Remember to copy all data files (from the `data/` directory) to your Flutter project's `assets/data/` folder and declare them in your `pubspec.yaml` under the `assets` section.
+```
+
+Remember to copy the `.lz` files (from the `data/` directory) into your application's assets and declare them in `pubspec.yaml`.
 
 ## Data Files
 
-Make sure the required data files are present in the `data/` directory:
+The following compressed `.lz` files are used by the library and are downloaded automatically when needed:
 
 - `muqathaat.lz`
 - `index_v.lz`
@@ -124,10 +113,12 @@ Make sure the required data files are present in the `data/` directory:
 - `quran_teks.lz`
 - `quran_trans_indonesian.lz`
 
+If you provide a custom `LafziFileLoader`, ensure these files are available in your chosen location.
+
 ## How It Works
 
-- The library loads compressed data files using Dart IO.
-- It decompresses and parses the data for fast search and retrieval.
+- The library downloads compressed data files on demand and caches them.
+- Files are decompressed and parsed for fast search and retrieval.
 - The `searchLafzi` method performs fuzzy matching and returns a list of matching verses.
 
 ## License


### PR DESCRIPTION
## Summary
- document automatic data download and caching features
- show how to load Quran text and translation with `searchLafzi`
- clarify custom file loading and data file requirements

## Testing
- `dart analyze` *(fails: multiple missing imports)*
- `dart test --reporter=expanded` *(fails: No test files were passed and the default "test/" directory doesn't exist)*

------
https://chatgpt.com/codex/tasks/task_e_68a55a6705b8832880d72fc21a18fb80